### PR TITLE
Fix otp redirection for admin role

### DIFF
--- a/src/screens/login/LoginScreen.tsx
+++ b/src/screens/login/LoginScreen.tsx
@@ -43,6 +43,8 @@ export function LoginScreen() {
         router.push("/superadmin");
       } else if (role === UserRole.MANAGER) {
         router.push("/admin");
+      } else if (role === UserRole.USER) {
+        router.push("/user");
       }
     } catch (err: any) {
       setError(err.message || "OTP verification failed. Please try again.");


### PR DESCRIPTION
Add redirection for 'user' role after successful OTP login.

Previously, the OTP login handler only redirected 'admin' and 'manager' roles, causing 'user' roles to get stuck on the OTP screen after successful verification.

---

[Open in Web](https://cursor.com/agents?id=bc-3ff8d9c8-551e-4181-8a12-cce0d11f172f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-3ff8d9c8-551e-4181-8a12-cce0d11f172f) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)