### PR TITLE
Fix otp redirection for admin role

### DIFF
--- a/ADMININSTRATION/src/screens/login/LoginScreen.tsx
+++ b/ADMININSTRATION/src/screens/login/LoginScreen.tsx
@@ -43,6 +43,8 @@ export function LoginScreen() {
         router.push("/superadmin");
       } else if (role === UserRole.MANAGER) {
         router.push("/admin");
+      } else if (role === UserRole.USER) {
+        router.push("/");
       }
     } catch (err: any) {
       setError(err.message || "OTP verification failed. Please try again.");


### PR DESCRIPTION
Add redirection for 'user' role after OTP login to fix users getting stuck on the OTP screen.

The existing OTP login flow only handled redirections for 'admin' and 'manager' roles, leaving 'user' role accounts stuck on the OTP screen after successful verification. This change ensures all defined roles are properly redirected.

---

[Open in Web](https://cursor.com/agents?id=bc-404d6fb2-c8c0-46b2-9794-372722a1152b) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-404d6fb2-c8c0-46b2-9794-372722a1152b) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)