### PR TITLE
Debug duplicate user count after pip implementation

### DIFF
--- a/components/MeetingRoom.tsx
+++ b/components/MeetingRoom.tsx
@@ -149,120 +149,149 @@ const MeetingRoom = () => {
         </ActionIcon>
       </Box>
 
-      {pipWindow
-        ? createPortal(
+      {pipWindow ? (
+        <>
+          {/* PiP Window Content */}
+          {createPortal(
             <StreamTheme>
-              <SpeakerLayout />
-              <CallControls />
+              <Box className="h-screen w-full">
+                <ParticipantsAudio participants={remoteParticipants} />
+                <SpeakerLayout />
+                <Box className="fixed bottom-0 flex w-full items-center justify-center gap-3 pb-4 z-50">
+                  <CallControls onLeave={() => router.replace("/")} />
+                </Box>
+              </Box>
             </StreamTheme>,
             pipWindow.document.body
-          )
-        : (
-          <>
-            <Box className="relative flex size-full items-center justify-center">
-              <Box
-                className={`flex size-full items-center justify-center ${
-                  showChat ? "chat-open" : ""
-                }`}
-              >
-                <ParticipantsAudio participants={remoteParticipants} />
-                <CallLayout />
+          )}
+          
+          {/* Main Window - Minimized View */}
+          <Box className="flex size-full items-center justify-center bg-gray-900">
+            <Box className="text-center">
+              <Box className="mb-4 text-2xl font-bold">Meeting in Picture-in-Picture</Box>
+              <Box className="text-gray-400">Your meeting is now running in a separate window</Box>
+              <Box className="mt-4">
+                <ActionIcon
+                  onClick={closePipWindow}
+                  title="Close Picture-in-Picture"
+                  size="lg"
+                  variant="filled"
+                  color="blue"
+                >
+                  <PiArrowDownRightBold size={24} />
+                </ActionIcon>
               </Box>
-
-              {showParticipants && (
-                <Box className="h-screen ml-5 hidden md:block">
-                  <CallParticipantsList onClose={() => setShowParticipants(false)} />
-                </Box>
-              )}
-
-              {showChat && (
-                <ChatPanel
-                  onClose={() => setShowChat(false)}
-                  onMarkAsRead={markAsReadFromPersistence}
-                  messages={messages}
-                  isOpen={showChat}
-                />
-              )}
             </Box>
-          </>
-        )}
-
-      <Box className="fixed bottom-0 flex flex-wrap w-full items-center justify-center gap-3 pb-4 z-50">
-        <CallControls onLeave={() => router.replace("/")} />
-        <Menu transitionProps={{ transition: "rotate-right", duration: 150 }}>
-          <Menu.Target>
-            <ActionIcon
-              title="Layout"
-              variant="transparent"
-              classNames={{ root: classes.action_bg }}
+          </Box>
+        </>
+      ) : (
+        <>
+          <Box className="relative flex size-full items-center justify-center">
+            <Box
+              className={`flex size-full items-center justify-center ${
+                showChat ? "chat-open" : ""
+              }`}
             >
-              <LuLayoutList size={20} />
-            </ActionIcon>
-          </Menu.Target>
-          <Menu.Dropdown classNames={{ dropdown: classes.menu_dropdown }}>
-            {["Grid", "Speaker-Left", "Speaker-Right"].map((type, idx) => (
-              <Menu.Item key={idx} onClick={() => setLayout(type.toLowerCase() as CallLayoutType)}>
-                {type}
-              </Menu.Item>
-            ))}
-          </Menu.Dropdown>
-        </Menu>
-        <ActionIcon
-          title="Participants"
-          variant="transparent"
-          classNames={{ root: classes.action_bg }}
-          onClick={() => setShowParticipants((p) => !p)}
-        >
-          <PiUsersThree size={20} />
-        </ActionIcon>
-        <Box pos="relative">
+              <ParticipantsAudio participants={remoteParticipants} />
+              <CallLayout />
+            </Box>
+
+            {showParticipants && (
+              <Box className="h-screen ml-5 hidden md:block">
+                <CallParticipantsList onClose={() => setShowParticipants(false)} />
+              </Box>
+            )}
+
+            {showChat && (
+              <ChatPanel
+                onClose={() => setShowChat(false)}
+                onMarkAsRead={markAsReadFromPersistence}
+                messages={messages}
+                isOpen={showChat}
+              />
+            )}
+          </Box>
+        </>
+      )}
+
+      {!pipWindow && (
+        <Box className="fixed bottom-0 flex flex-wrap w-full items-center justify-center gap-3 pb-4 z-50">
+          <CallControls onLeave={() => router.replace("/")} />
+          <Menu transitionProps={{ transition: "rotate-right", duration: 150 }}>
+            <Menu.Target>
+              <ActionIcon
+                title="Layout"
+                variant="transparent"
+                classNames={{ root: classes.action_bg }}
+              >
+                <LuLayoutList size={20} />
+              </ActionIcon>
+            </Menu.Target>
+            <Menu.Dropdown classNames={{ dropdown: classes.menu_dropdown }}>
+              {["Grid", "Speaker-Left", "Speaker-Right"].map((type, idx) => (
+                <Menu.Item key={idx} onClick={() => setLayout(type.toLowerCase() as CallLayoutType)}>
+                  {type}
+                </Menu.Item>
+              ))}
+            </Menu.Dropdown>
+          </Menu>
           <ActionIcon
-            title="Chat"
+            title="Participants"
             variant="transparent"
             classNames={{ root: classes.action_bg }}
-            onClick={() => {
-              setShowChat((prev) => {
-                const willOpen = !prev;
-                if (willOpen) markAsRead();
-                return willOpen;
-              });
-            }}
+            onClick={() => setShowParticipants((p) => !p)}
           >
-            <IoChatbubbleEllipsesOutline size={20} />
+            <PiUsersThree size={20} />
           </ActionIcon>
-          <Transition
-            mounted={hasUnreadMessages && unreadCount > 0}
-            transition="pop"
-            duration={200}
-            timingFunction="ease"
-          >
-            {(styles) => (
-              <Badge
-                size="xs"
-                variant="filled"
-                color="red"
-                pos="absolute"
-                top={-8}
-                right={-8}
-                style={{
-                  minWidth: "18px",
-                  height: "18px",
-                  fontSize: "10px",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  borderRadius: "50%",
-                  ...styles,
-                }}
-              >
-                {unreadCount > 9 ? "9+" : unreadCount}
-              </Badge>
-            )}
-          </Transition>
+          <Box pos="relative">
+            <ActionIcon
+              title="Chat"
+              variant="transparent"
+              classNames={{ root: classes.action_bg }}
+              onClick={() => {
+                setShowChat((prev) => {
+                  const willOpen = !prev;
+                  if (willOpen) markAsRead();
+                  return willOpen;
+                });
+              }}
+            >
+              <IoChatbubbleEllipsesOutline size={20} />
+            </ActionIcon>
+            <Transition
+              mounted={hasUnreadMessages && unreadCount > 0}
+              transition="pop"
+              duration={200}
+              timingFunction="ease"
+            >
+              {(styles) => (
+                <Badge
+                  size="xs"
+                  variant="filled"
+                  color="red"
+                  pos="absolute"
+                  top={-8}
+                  right={-8}
+                  style={{
+                    minWidth: "18px",
+                    height: "18px",
+                    fontSize: "10px",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    borderRadius: "50%",
+                    ...styles,
+                  }}
+                >
+                  {unreadCount > 9 ? "9+" : unreadCount}
+                </Badge>
+              )}
+            </Transition>
+          </Box>
+          <CallStatsButton />
+          {!isPersonalRoom && <EndCallButton />}
         </Box>
-        <CallStatsButton />
-        {!isPersonalRoom && <EndCallButton />}
-      </Box>
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
Conditionally render meeting content and controls to prevent duplicate participants when Picture-in-Picture is active.

Previously, when Picture-in-Picture (PiP) mode was active, the `MeetingRoom` component rendered the meeting content in both the main window and the PiP window simultaneously. This resulted in the Stream video SDK showing the same participant twice, as both instances were connected to the same call. This PR ensures that the meeting content is rendered only in the active PiP window, while the main window displays a minimized view.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ce5012d-7ff2-45e3-8bc0-399325e9d7bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4ce5012d-7ff2-45e3-8bc0-399325e9d7bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

